### PR TITLE
Fixed Carriage Return and Line Feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-
-
+package-lock.json
 yarn.lock
-
 node_modules/

--- a/index.js
+++ b/index.js
@@ -1,21 +1,23 @@
-const YAML = require('js-yaml');
+const YAML = require("js-yaml");
 
 /**
  * matter
- * @param {*} str 
- * @param {*} options 
- * @returns 
+ * @param {*} str
+ * @param {*} options
+ * @returns
  */
-const matter = (str = '', options) => {
-  const { delimiters, parser: parse } = Object.assign({
-    delimiters: ['---', '---'],
-    parser: YAML.load,
-  }, options);
+const matter = (str = "", options) => {
+  const { delimiters, parser: parse } = Object.assign(
+    {
+      delimiters: ["---", "---"],
+      parser: YAML.load,
+    },
+    options
+  );
   const [open, close] = delimiters;
-  const r1 = new RegExp(`^${open}\n`);
-  const r2 = new RegExp(`\n${close}\n`);
-  if (!(r1.test(str) && r2.test(str)))
-    return { content: str };
+  const r1 = new RegExp(`^${open}[\r\n]`);
+  const r2 = new RegExp(`[\r\n]${close}[\r\n]`);
+  if (!(r1.test(str) && r2.test(str))) return { content: str };
   const x = r1.exec(str);
   const i = x[0].length;
   const y = r2.exec(str.substr(i));
@@ -23,7 +25,13 @@ const matter = (str = '', options) => {
   const k = j + y[0].length;
   const front = str.substring(i, j);
   const data = parse(front);
-  const content = str.slice(k);
+  let content = str.slice(k);
+  if (content[0] === "\r") {
+    content = content.slice(1);
+  }
+  if (content[0] === "\n") {
+    content = content.slice(1);
+  }
   return { data, content };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-matter",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Super Tiny Front Matter Parser",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -40,3 +40,13 @@ test("matter#delimiters", () => {
   assert.strictEqual(x.data.title, "Front Matter");
   assert.strictEqual(x.content, "This is content.");
 });
+
+test("matter#crlf", () => {
+  const x = matter('---\r\ntitle: Front Matter\r\n---\r\nThis is content.')
+  assert.ok(x);
+  assert.strictEqual(typeof x, 'object');
+  assert.strictEqual(typeof x.data, 'object');
+  assert.strictEqual(typeof x.content, 'string');
+  assert.strictEqual(x.data.title, "Front Matter");
+  assert.strictEqual(x.content, "This is content.");
+});


### PR DESCRIPTION
## Reference Issues/PRs

None

## What does this implement/fix?

Thanks for this awesome converter!

- Fixed an issue where objects were not converted at all, when using [Carriage Return and Line Feed](https://stackoverflow.com/questions/1552749/difference-between-cr-lf-lf-and-cr-line-break-types/39259747#39259747) line break (Windows)
- Added test case
- Updated .gitignore
- Bumped version in package.json

### Test results

Without fix:

```shell
✘  matter#crlf

  AssertionError: Expected values to be strictly equal:
+ actual - expected

+ 'undefined'
- 'object'
  expected: 'object'
    actual: 'undefined'
```

With fix:

```shell
✔  matter#empty
✔  matter#normal
✔  matter#json
✔  matter#delimiters
✔  matter#crlf
```