### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Into an object like this:
 ### Install
 
 ```sh
-~$ npm i tiny-matter --save
+npm i tiny-matter --save
 ```
 
 ### Example


### PR DESCRIPTION
The ~ and the $ at the installation command will trigger an error if copied directly. Removed ~ and $ from the installation command so it will work directly in a terminal.

Otherwise ~ and $ has to be manually removed before running the command